### PR TITLE
Add time-sync, fix depth registration, and add subsampling in frame-rate

### DIFF
--- a/realsense_camera/CMakeLists.txt
+++ b/realsense_camera/CMakeLists.txt
@@ -100,7 +100,7 @@ include_directories(
 )
 
 add_library(${PROJECT_NAME}_nodelet src/base_nodelet.cpp src/sync_nodelet.cpp src/r200_nodelet.cpp src/f200_nodelet.cpp src/sr300_nodelet.cpp
-  src/zr300_nodelet.cpp)
+  src/zr300_nodelet.cpp src/time_sync.cpp)
 target_link_libraries(${PROJECT_NAME}_nodelet
   ${catkin_LIBRARIES}
 )

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -118,6 +118,9 @@ protected:
   int unit_step_size_[STREAM_COUNT];
   int step_[STREAM_COUNT];
   double ts_[STREAM_COUNT];
+  // Sequence numbers (or frame IDs in the realsense frame, not TF) for images,
+  // for timestamp resolution and publishing.
+  int sequence_ids_[STREAM_COUNT];
   std::string frame_id_[STREAM_COUNT];
   std::string optical_frame_id_[STREAM_COUNT];
   cv::Mat image_[STREAM_COUNT] = {};

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -172,7 +172,7 @@ protected:
   virtual void disableStream(rs_stream stream_index);
   virtual std::string startCamera();
   virtual std::string stopCamera();
-  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts);
+  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number);
   virtual void publishTopic(rs_stream stream_index, rs::frame &  frame);
   virtual void setImageData(rs_stream stream_index, rs::frame &  frame);
   virtual void publishPCTopic();

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -121,6 +121,8 @@ protected:
   // Sequence numbers (or frame IDs in the realsense frame, not TF) for images,
   // for timestamp resolution and publishing.
   int sequence_ids_[STREAM_COUNT];
+  // What factor to subsample the FPS by. INTEGER ONLY. Because it's easier.
+  int subsample_fps_[STREAM_COUNT] = {1};
   std::string frame_id_[STREAM_COUNT];
   std::string optical_frame_id_[STREAM_COUNT];
   cv::Mat image_[STREAM_COUNT] = {};

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -129,7 +129,7 @@ protected:
   std::string base_frame_id_;
   float max_z_ = -1.0f;
   bool enable_pointcloud_;
-    bool enforce_rgbd_sync_;
+  bool enforce_rgbd_sync_;
   bool enable_tf_;
   bool enable_tf_dynamic_;
   double tf_publication_rate_;

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -129,6 +129,7 @@ protected:
   std::string base_frame_id_;
   float max_z_ = -1.0f;
   bool enable_pointcloud_;
+    bool enforce_rgbd_sync_;
   bool enable_tf_;
   bool enable_tf_dynamic_;
   double tf_publication_rate_;

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -85,6 +85,7 @@ namespace realsense_camera
     const double ROTATION_IDENTITY[] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
     const float MILLIMETER_METERS  = 0.001;
     const double MILLISECONDS_TO_SECONDS = 0.001;
+    const size_t TIMESTAMP_QUEUE_MAX_SIZE = 200;
 
     // R200 and ZR300 Constants.
     const std::string IR2_NAMESPACE = "ir2";

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -57,6 +57,7 @@ namespace realsense_camera
     const bool ENABLE_FISHEYE = true;
     const bool ENABLE_IMU = true;
     const bool ENABLE_PC = false;
+    const bool ENFORCE_RGBD_SYNC = true;
     const bool ENABLE_TF = true;
     const bool ENABLE_TF_DYNAMIC = false;
     const double TF_PUBLICATION_RATE = 1.0;

--- a/realsense_camera/include/realsense_camera/constants.h
+++ b/realsense_camera/include/realsense_camera/constants.h
@@ -84,6 +84,7 @@ namespace realsense_camera
     const int EVENT_COUNT = 2;
     const double ROTATION_IDENTITY[] = {1, 0, 0, 0, 1, 0, 0, 0, 1};
     const float MILLIMETER_METERS  = 0.001;
+    const double MILLISECONDS_TO_SECONDS = 0.001;
 
     // R200 and ZR300 Constants.
     const std::string IR2_NAMESPACE = "ir2";

--- a/realsense_camera/include/realsense_camera/time_sync.h
+++ b/realsense_camera/include/realsense_camera/time_sync.h
@@ -1,0 +1,49 @@
+/*
+ * time_sync.h
+ *
+ *  Created on: Sep 21, 2016
+ *      Authors: Michael Burri, Helen Oleynikova
+ */
+
+#include <iostream>
+
+#include <Eigen/Dense>
+#include <ros/ros.h>
+
+#ifndef REALSENSE_CAMERA_TIME_SYNC_H_
+#define REALSENSE_CAMERA_TIME_SYNC_H_
+
+namespace realsense_ros {
+
+class TimeSyncFilter {
+ public:
+  static constexpr double kSigmaInitOffset = 2e-3;
+  static constexpr double kSigmaInitSkew = 1e-3;
+  static constexpr double kSigmaMeasurementTimeOffset = 2e-3;
+  static constexpr double kSigmaSkew = 2e-6;
+  static constexpr double kSigmaOffset = 1e-5;
+  static constexpr double kUpdateRate = 0.1; // (1/sec)
+
+  TimeSyncFilter();
+  ~TimeSyncFilter() {};
+  double getLocalTimestamp(double device_time);
+  void updateFilter(double device_time, double local_time);
+  void print();
+  void reset();
+ private:
+  void initialize(double device_time, double local_time);
+  bool isOutlier(double device_time, double local_time);
+
+  Eigen::Vector2d x_;
+  Eigen::Matrix2d P_;
+  Eigen::Matrix2d Q_;
+  double R_;
+  Eigen::Matrix<double, 1, 2> H_;
+  bool is_initialized_;
+  double last_update_device_time_;
+  double dt_;
+};
+
+}  // realsense ros
+
+#endif  // REALSENSE_CAMERA_TIME_SYNC_H_

--- a/realsense_camera/include/realsense_camera/time_sync.h
+++ b/realsense_camera/include/realsense_camera/time_sync.h
@@ -28,8 +28,9 @@ class TimeSyncFilter {
   ~TimeSyncFilter() {};
   double getLocalTimestamp(double device_time);
   void updateFilter(double device_time, double local_time);
-  void print();
+  void print() const;
   void reset();
+  bool isInitialized() const;
  private:
   void initialize(double device_time, double local_time);
   bool isOutlier(double device_time, double local_time);

--- a/realsense_camera/include/realsense_camera/time_sync.h
+++ b/realsense_camera/include/realsense_camera/time_sync.h
@@ -13,7 +13,7 @@
 #ifndef REALSENSE_CAMERA_TIME_SYNC_H_
 #define REALSENSE_CAMERA_TIME_SYNC_H_
 
-namespace realsense_ros {
+namespace realsense_camera {
 
 class TimeSyncFilter {
  public:
@@ -44,6 +44,6 @@ class TimeSyncFilter {
   double dt_;
 };
 
-}  // realsense ros
+}  // namespace realsense_camera
 
 #endif  // REALSENSE_CAMERA_TIME_SYNC_H_

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -42,6 +42,7 @@
 #include <realsense_camera/IMUInfo.h>
 #include <realsense_camera/GetIMUInfo.h>
 #include <realsense_camera/base_nodelet.h>
+#include <realsense_camera/time_sync.h>
 
 namespace realsense_camera
 {
@@ -71,6 +72,9 @@ protected:
   rs_extrinsics color2ir2_extrinsic_;      // color frame is base frame
   rs_extrinsics color2fisheye_extrinsic_;  // color frame is base frame
   rs_extrinsics color2imu_extrinsic_;      // color frame is base frame
+
+  // Time synchronizer.
+  TimeSyncFilter time_sync_;
 
   // Member Functions.
   void getParameters();

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -61,8 +61,8 @@ protected:
   std::string imu_optical_frame_id_;
   geometry_msgs::Vector3 imu_angular_vel_;
   geometry_msgs::Vector3 imu_linear_accel_;
-  double imu_ts_;
-  double prev_imu_ts_;
+  double imu_ts_device_time_;
+  double prev_imu_ts_device_time_;
   ros::Publisher imu_publisher_;
   boost::shared_ptr<boost::thread> imu_thread_;
   std::function<void(rs::motion_data)> motion_handler_;
@@ -75,6 +75,10 @@ protected:
 
   // Time synchronizer.
   TimeSyncFilter time_sync_;
+
+  // Queue of timestamps to sync everything to IMU clock.
+  mutable std::mutex timestamp_mutex_;
+  std::deque<rs::timestamp_data> timestamp_queue_;
 
   // Member Functions.
   void getParameters();
@@ -95,6 +99,10 @@ protected:
   void setFrameCallbacks();
   std::function<void(rs::frame f)> fisheye_frame_handler_, ir2_frame_handler_;
   void stopIMU();
+  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number);
+  bool findTimestamp(unsigned short sequence_number, rs_event_source source,
+      int* timestamp_imu, ros::Time* timestamp);
+
 };
 }  // namespace realsense_camera
 #endif  // REALSENSE_CAMERA_ZR300_NODELET_H

--- a/realsense_camera/launch/includes/nodelet.launch.xml
+++ b/realsense_camera/launch/includes/nodelet.launch.xml
@@ -30,6 +30,9 @@
     <param name="fisheye_optical_frame_id" type="str"  value="$(arg camera)_fisheye_optical_frame" />
     <param name="imu_optical_frame_id"     type="str"  value="$(arg camera)_imu_optical_frame" />
 
+    <param name="enable_pointcloud"  value="true" />
+
+
     <remap from="depth"    to="$(arg depth)" />
     <remap from="color"    to="$(arg rgb)" />
     <remap from="ir"       to="$(arg ir)" />

--- a/realsense_camera/launch/zr300_nodelet_default.launch
+++ b/realsense_camera/launch/zr300_nodelet_default.launch
@@ -9,14 +9,16 @@
   <!-- These 'arg' tags are just place-holders for passing values from test files.
   The recommended way is to pass the values directly into the 'param' tags. -->
   <arg name="mode"              default="manual" />
-  <arg name="color_fps"         default="30" />
+  <arg name="color_fps"         default="60" />
   <arg name="fisheye_fps"       default="30" />
+  <arg name="depth_fps"         default="60" />
   <arg name="fisheye_strobe"    default="1" />
   <arg name="fisheye_external_trigger"    default="1" />
 
   <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
   <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
   <param name="$(arg camera)/driver/fisheye_fps"       type="int"  value="$(arg fisheye_fps)" />
+  <param name="$(arg camera)/driver/depth_fps"       type="int"  value="$(arg depth_fps)" />
   <param name="$(arg camera)/driver/fisheye_strobe"    type="int"  value="$(arg fisheye_strobe)" />
   <param name="$(arg camera)/driver/fisheye_external_trigger"    type="int"  value="$(arg fisheye_external_trigger)" />
   <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->

--- a/realsense_camera/launch/zr300_nodelet_default.launch
+++ b/realsense_camera/launch/zr300_nodelet_default.launch
@@ -14,6 +14,8 @@
   <arg name="depth_fps"         default="30" />
   <arg name="fisheye_strobe"    default="1" />
   <arg name="fisheye_external_trigger"    default="1" />
+  <arg name="enable_imu"    default="true" />
+
 
   <param name="$(arg camera)/driver/mode"              type="str"  value="$(arg mode)" />
   <param name="$(arg camera)/driver/color_fps"         type="int"  value="$(arg color_fps)" />
@@ -21,6 +23,7 @@
   <param name="$(arg camera)/driver/depth_fps"       type="int"  value="$(arg depth_fps)" />
   <param name="$(arg camera)/driver/fisheye_strobe"    type="int"  value="$(arg fisheye_strobe)" />
   <param name="$(arg camera)/driver/fisheye_external_trigger"    type="int"  value="$(arg fisheye_external_trigger)" />
+  <param name="$(arg camera)/driver/enable_imu"     value="$(arg enable_imu)" />
   <!-- Refer to the Wiki http://wiki.ros.org/realsense_camera for list of supported parameters -->
 
   <group ns="$(arg camera)">

--- a/realsense_camera/launch/zr300_nodelet_default.launch
+++ b/realsense_camera/launch/zr300_nodelet_default.launch
@@ -9,9 +9,9 @@
   <!-- These 'arg' tags are just place-holders for passing values from test files.
   The recommended way is to pass the values directly into the 'param' tags. -->
   <arg name="mode"              default="manual" />
-  <arg name="color_fps"         default="60" />
+  <arg name="color_fps"         default="30" />
   <arg name="fisheye_fps"       default="30" />
-  <arg name="depth_fps"         default="60" />
+  <arg name="depth_fps"         default="30" />
   <arg name="fisheye_strobe"    default="1" />
   <arg name="fisheye_external_trigger"    default="1" />
 

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -34,15 +34,12 @@
 #include <vector>
 #include <map>
 #include <realsense_camera/base_nodelet.h>
-#define _GNU_SOURCE
 #include <unistd.h>
 
 using cv::Mat;
 using cv::Scalar;
 using std::string;
 using std::vector;
-
-extern char** environ;
 
 PLUGINLIB_EXPORT_CLASS(realsense_camera::BaseNodelet, nodelet::Nodelet)
 namespace realsense_camera
@@ -865,7 +862,7 @@ namespace realsense_camera
   /*
    * Determine the timestamp for the publish topic.
    */
-  ros::Time BaseNodelet::getTimestamp(rs_stream stream_index, double frame_ts)
+  ros::Time BaseNodelet::getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number)
   {
     return ros::Time(camera_start_ts_) + ros::Duration(frame_ts * 0.001);
   }
@@ -892,7 +889,7 @@ namespace realsense_camera
                                 image_[stream_index]).toImageMsg();
         msg->header.frame_id = optical_frame_id_[stream_index];
         // Publish timestamp to synchronize frames.
-        msg->header.stamp = getTimestamp(stream_index, frame_ts);
+        msg->header.stamp = getTimestamp(stream_index, frame_ts, frame.get_frame_number());
         msg->width = image_[stream_index].cols;
         msg->height = image_[stream_index].rows;
         msg->is_bigendian = false;
@@ -958,7 +955,7 @@ namespace realsense_camera
       sensor_msgs::PointCloud2 msg_pointcloud;
       msg_pointcloud.width = width_[RS_STREAM_DEPTH];
       msg_pointcloud.height = height_[RS_STREAM_DEPTH];
-      msg_pointcloud.header.stamp = getTimestamp(RS_STREAM_DEPTH, ts_[RS_STREAM_DEPTH]);
+      msg_pointcloud.header.stamp = getTimestamp(RS_STREAM_DEPTH, ts_[RS_STREAM_DEPTH], sequence_ids_[RS_STREAM_DEPTH]);
       msg_pointcloud.is_dense = true;
 
       sensor_msgs::PointCloud2Modifier modifier(msg_pointcloud);

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -28,16 +28,21 @@
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************/
 
+
 #include <string>
 #include <algorithm>
 #include <vector>
 #include <map>
 #include <realsense_camera/base_nodelet.h>
+#define _GNU_SOURCE
+#include <unistd.h>
 
 using cv::Mat;
 using cv::Scalar;
 using std::string;
 using std::vector;
+
+extern char** environ;
 
 PLUGINLIB_EXPORT_CLASS(realsense_camera::BaseNodelet, nodelet::Nodelet)
 namespace realsense_camera
@@ -1269,7 +1274,7 @@ namespace realsense_camera
       // sleep for 1 second to ensure previous calls are completed
       sleep(1);
       // environ is the current environment from <unistd.h>
-      execvpe(argv[0], argv, environ);
+      //execvpe(argv[0], argv, environ);
 
       _exit(EXIT_FAILURE);  // exec never returns
     }

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -933,7 +933,6 @@ namespace realsense_camera
     // Check if the depth and rgb sequence numbers match; otherwise we're out
     // of sync anyway.
     if (enforce_rgbd_sync_ && sequence_ids_[RS_STREAM_COLOR] != sequence_ids_[RS_STREAM_DEPTH]) {
-      ROS_WARN_THROTTLE(1.0, "Mismatched IDs: color: %d depth: %d", sequence_ids_[RS_STREAM_COLOR], sequence_ids_[RS_STREAM_DEPTH]);
       return;
     }
     cv::Mat & image_color = image_[RS_STREAM_COLOR];

--- a/realsense_camera/src/time_sync.cpp
+++ b/realsense_camera/src/time_sync.cpp
@@ -1,0 +1,94 @@
+/*
+ * time_sync.cpp
+ *
+ *  Created on: Sep 21, 2016
+ *      Authors: Michael Burri, Helen Oleynikova
+ */
+
+#include "realsense_ros/time_sync.h"
+
+namespace realsense_ros {
+
+TimeSyncFilter::TimeSyncFilter() : is_initialized_(false) {}
+
+double TimeSyncFilter::getLocalTimestamp(double device_time) {
+  if (!is_initialized_) {
+    std::cout << "[WARN]: Timesync filter not initialized yet! Hack "
+                 "initializing now.";
+    double local_time = ros::Time::now().toSec();
+    initialize(device_time, local_time);
+  }
+  double dt = device_time - last_update_device_time_;
+  return device_time + x_(0) + dt * x_(1);
+}
+
+void TimeSyncFilter::print() {
+  std::cout << "offset: " << x_(0) << "skew: " << x_(1) << "dt" << dt_
+            << std::endl;
+  // std::cout << P_<< std::endl;
+}
+
+void TimeSyncFilter::reset() { is_initialized_ = 0; }
+
+void TimeSyncFilter::updateFilter(double device_time, double local_time) {
+  if (!is_initialized_) {
+    initialize(device_time, local_time);
+    return;
+  }
+
+  double dt = device_time - last_update_device_time_;
+
+  if (dt < kUpdateRate) return;
+
+  dt_ = dt;
+  Eigen::Matrix2d F;
+  F << 1, dt_, 0, 1;
+
+  // Prediction
+  Eigen::Vector2d x_pred = F * x_;
+
+  // check for outlier
+  double measurement_residual = local_time - device_time - H_ * x_pred;
+
+  if (measurement_residual > 2 * kSigmaMeasurementTimeOffset) {
+    // std::cout << "Timesync outlier" << std::endl;
+    return;
+  }
+
+  P_ = F * P_ * F.transpose() + dt_ * Q_;
+
+  // Update
+  double S = H_ * P_ * H_.transpose() + R_;
+
+  Eigen::Vector2d K;
+  K = P_ * H_.transpose() * (1 / S);
+
+  x_ = x_pred + K * measurement_residual;
+  P_ = (Eigen::Matrix2d::Identity() - K * H_) * P_;
+
+  last_update_device_time_ = device_time;
+
+  // print();
+}
+
+void TimeSyncFilter::initialize(double device_time, double local_time) {
+  x_.setZero();
+  x_[0] = local_time - device_time;
+
+  P_.setZero();
+  P_(0, 0) = kSigmaInitOffset * kSigmaInitOffset;
+  P_(1, 1) = kSigmaInitSkew * kSigmaInitSkew;
+
+  Q_.setZero();
+  Q_(0, 0) = kSigmaOffset * kSigmaOffset;
+  Q_(1, 1) = kSigmaSkew * kSigmaSkew;
+
+  R_ = kSigmaMeasurementTimeOffset * kSigmaMeasurementTimeOffset;
+
+  H_.setZero();
+  H_(0, 0) = 1;
+
+  last_update_device_time_ = device_time;
+  is_initialized_ = true;
+}
+}

--- a/realsense_camera/src/time_sync.cpp
+++ b/realsense_camera/src/time_sync.cpp
@@ -22,7 +22,7 @@ double TimeSyncFilter::getLocalTimestamp(double device_time) {
   return device_time + x_(0) + dt * x_(1);
 }
 
-void TimeSyncFilter::print() {
+void TimeSyncFilter::print() const {
   std::cout << "offset: " << x_(0) << "skew: " << x_(1) << "dt" << dt_
             << std::endl;
   // std::cout << P_<< std::endl;
@@ -90,6 +90,10 @@ void TimeSyncFilter::initialize(double device_time, double local_time) {
 
   last_update_device_time_ = device_time;
   is_initialized_ = true;
+}
+
+bool TimeSyncFilter::isInitialized() const {
+  return is_initialized_;
 }
 
 }  // namespace realsense_camera

--- a/realsense_camera/src/time_sync.cpp
+++ b/realsense_camera/src/time_sync.cpp
@@ -5,9 +5,9 @@
  *      Authors: Michael Burri, Helen Oleynikova
  */
 
-#include "realsense_ros/time_sync.h"
+#include "realsense_camera/time_sync.h"
 
-namespace realsense_ros {
+namespace realsense_camera {
 
 TimeSyncFilter::TimeSyncFilter() : is_initialized_(false) {}
 
@@ -91,4 +91,5 @@ void TimeSyncFilter::initialize(double device_time, double local_time) {
   last_update_device_time_ = device_time;
   is_initialized_ = true;
 }
-}
+
+}  // namespace realsense_camera

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -521,7 +521,7 @@ namespace realsense_camera
    */
   void ZR300Nodelet::publishIMU()
   {
-    prev_imu_ts_ = -1;
+    prev_imu_ts_device_time_ = -1;
     while (ros::ok())
     {
       if (start_stop_srv_called_ == true)
@@ -548,10 +548,11 @@ namespace realsense_camera
       {
         std::unique_lock<std::mutex> lock(imu_mutex_);
 
-        if (prev_imu_ts_ != imu_ts_)
+        // Super sketchy double equals check... Maybe switch to sequence number?
+        if (prev_imu_ts_device_time_ != imu_ts_device_time_)
         {
           sensor_msgs::Imu imu_msg = sensor_msgs::Imu();
-          imu_msg.header.stamp = ros::Time(camera_start_ts_) + ros::Duration(imu_ts_ * 0.001);
+          imu_msg.header.stamp = ros::Time(time_sync_.getLocalTimestamp(imu_ts_device_time_));
           imu_msg.header.frame_id = imu_optical_frame_id_;
 
           // Setting just the first element to -1.0 because device does not give orientation data
@@ -561,9 +562,8 @@ namespace realsense_camera
           imu_msg.linear_acceleration = imu_linear_accel_;
 
           imu_publisher_.publish(imu_msg);
-          prev_imu_ts_ = imu_ts_;
+          prev_imu_ts_device_time_ = imu_ts_device_time_;
         }
-        sleep(1000);
       }
     }
     stopIMU();
@@ -596,13 +596,14 @@ namespace realsense_camera
   {
     motion_handler_ = [&](rs::motion_data entry)  // NOLINT(build/c++11)
     {
-      ROS_INFO("IMU callback.");
       std::unique_lock<std::mutex> lock(imu_mutex_);
       if (entry.timestamp_data.source_id == RS_EVENT_IMU_GYRO)
       {
         imu_angular_vel_.x = entry.axes[0];
         imu_angular_vel_.y = entry.axes[1];
         imu_angular_vel_.z = entry.axes[2];
+        // Only update timestamp on gyro!
+        imu_ts_device_time_ = static_cast<double>(entry.timestamp_data.timestamp) * MILLISECONDS_TO_SECONDS;
       }
       else if (entry.timestamp_data.source_id == RS_EVENT_IMU_ACCEL)
       {
@@ -610,10 +611,9 @@ namespace realsense_camera
         imu_linear_accel_.y = entry.axes[1];
         imu_linear_accel_.z = entry.axes[2];
       }
-      imu_ts_ = static_cast<double>(entry.timestamp_data.timestamp);
 
-      ROS_INFO_STREAM(" - Motion,\t host time " << imu_ts_
-          << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*IMU_UNITS_TO_MSEC
+      ROS_DEBUG_STREAM(" - Motion,\t host time " << imu_ts_device_time_
+          << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*MILLISECONDS_TO_SECONDS
           << "\tsource: " << (rs::event)entry.timestamp_data.source_id
           << "\tframe_num: " << entry.timestamp_data.frame_number
           << "\tx: " << std::setprecision(5) <<  entry.axes[0]
@@ -622,21 +622,34 @@ namespace realsense_camera
     };
 
     // Get timestamp that syncs all sensors.
-    timestamp_handler_ = [](rs::timestamp_data entry)
+    timestamp_handler_ = [&](rs::timestamp_data entry)
     {
-        ROS_INFO("Timestamp callback.");
         // Debug output for fun:
         auto now = std::chrono::system_clock::now().time_since_epoch();
         auto sys_time = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
 
-        ROS_INFO_STREAM(" - TimeEvent, host time " << sys_time
-            << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp*IMU_UNITS_TO_MSEC
+        ROS_DEBUG_STREAM(" - TimeEvent, host time " << sys_time
+            << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp*MILLISECONDS_TO_SECONDS
             << "\tsource: " << (rs::event)entry.source_id
             << "\tframe_num: " << entry.frame_number);
 
         // Time sync output for profit.
         double time_now = ros::Time::now().toSec();
 
+        if (!time_sync_.isInitialized() ||
+            (rs::event)entry.source_id == rs::event::event_imu_depth_cam ||
+            (rs::event)entry.source_id == rs::event::event_imu_motion_cam) {
+          // TODO: check if this is correct -- should we keep first timestamp
+          // checks outside?
+          time_sync_.updateFilter(
+              static_cast<double>(entry.timestamp) * MILLISECONDS_TO_SECONDS,
+              time_now);
+
+          timestamp_queue_.push_back(entry);
+          while (timestamp_queue_.size() >= TIMESTAMP_QUEUE_MAX_SIZE) {
+            timestamp_queue_.pop_front();
+          }
+        }
     };
   }
 
@@ -875,4 +888,39 @@ namespace realsense_camera
     rs_disable_motion_tracking(rs_device_, &rs_error_);
     checkError();
   }
+
+  ros::Time ZR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number) {
+    ros::Time local_timestamp;
+
+    findTimestamp(sequence_number, RS_EVENT_IMU_MOTION_CAM, nullptr,
+                    &local_timestamp);
+    return local_timestamp;
+  }
+
+  bool ZR300Nodelet::findTimestamp(unsigned short sequence_number, rs_event_source source,
+      int* timestamp_imu, ros::Time* timestamp) {
+    std::lock_guard<std::mutex> lock(timestamp_mutex_);
+
+    for (auto ts : timestamp_queue_) {
+      if (ts.source_id == source && ts.frame_number == sequence_number) {
+        if (timestamp_imu) {
+          *timestamp_imu = ts.timestamp;
+        }
+        if (timestamp) {
+          double device_time =
+              static_cast<double>(ts.timestamp) * MILLISECONDS_TO_SECONDS;
+          ros::Time local_time;
+          double local_timestamp;
+          local_timestamp = time_sync_.getLocalTimestamp(device_time);
+          local_time.fromSec(local_timestamp);
+          *timestamp = local_time;
+        }
+        return true;
+      }
+    }
+    ROS_WARN("Looking for sequence number: %d, could not find it as first and last are %d and %d",
+      sequence_number, timestamp_queue_.front().frame_number, timestamp_queue_.back().frame_number);
+    return false;
+  }
+
 }  // namespace realsense_camera

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -892,8 +892,13 @@ namespace realsense_camera
   ros::Time ZR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number) {
     ros::Time local_timestamp;
 
-    findTimestamp(sequence_number, RS_EVENT_IMU_MOTION_CAM, nullptr,
-                    &local_timestamp);
+    if (stream_index == RS_STREAM_FISHEYE) {
+      findTimestamp(sequence_number, RS_EVENT_IMU_MOTION_CAM, nullptr,
+                      &local_timestamp);
+    } else {
+      findTimestamp(sequence_number, RS_EVENT_IMU_DEPTH_CAM, nullptr,
+                      &local_timestamp);
+    }
     return local_timestamp;
   }
 
@@ -918,7 +923,7 @@ namespace realsense_camera
         return true;
       }
     }
-    ROS_WARN("Looking for sequence number: %d, could not find it as first and last are %d and %d",
+    ROS_WARN("Looking for sequence number: %d, could not find it as first and last are %llu and %llu",
       sequence_number, timestamp_queue_.front().frame_number, timestamp_queue_.back().frame_number);
     return false;
   }


### PR DESCRIPTION
This driver should now be comparable (but somewhat cleaner!) to our private driver.

Maybe a few last issues to look at are the CPU costs (IMU publish busy loop, for example), improving time sync (either outlier rejection or switch to Hannes's version), and ???

@ZacharyTaylor @alexmillane @burrimi 

