### PR TITLE
don't poll imu so we don't eat the whole core

### DIFF
--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -59,15 +59,9 @@ protected:
   bool enable_imu_;
   std::string imu_frame_id_;
   std::string imu_optical_frame_id_;
-  geometry_msgs::Vector3 imu_angular_vel_;
-  geometry_msgs::Vector3 imu_linear_accel_;
-  double imu_ts_device_time_;
-  double prev_imu_ts_device_time_;
   ros::Publisher imu_publisher_;
-  boost::shared_ptr<boost::thread> imu_thread_;
   std::function<void(rs::motion_data)> motion_handler_;
   std::function<void(rs::timestamp_data)> timestamp_handler_;
-  std::mutex imu_mutex_;
 
   rs_extrinsics color2ir2_extrinsic_;      // color frame is base frame
   rs_extrinsics color2fisheye_extrinsic_;  // color frame is base frame
@@ -77,7 +71,6 @@ protected:
   TimeSyncFilter time_sync_;
 
   // Queue of timestamps to sync everything to IMU clock.
-  mutable std::mutex timestamp_mutex_;
   std::deque<rs::timestamp_data> timestamp_queue_;
 
   // Member Functions.
@@ -93,7 +86,6 @@ protected:
   void getCameraExtrinsics();
   void publishStaticTransforms();
   void publishDynamicTransforms();
-  void publishIMU();
   void setStreams();
   void setIMUCallbacks();
   void setFrameCallbacks();

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -46,8 +46,6 @@ namespace realsense_camera
     if (enable_imu_ == true)
     {
       stopIMU();
-      // clean up imu thread
-      imu_thread_->join();
     }
   }
 
@@ -84,12 +82,6 @@ namespace realsense_camera
     max_z_ = ZR300_MAX_Z;
 
     BaseNodelet::onInit();
-
-    if (enable_imu_ == true)
-    {
-      imu_thread_ =
-          boost::shared_ptr<boost::thread>(new boost::thread(boost::bind(&ZR300Nodelet::publishIMU, this)));
-    }
   }
 
   /*
@@ -517,59 +509,6 @@ namespace realsense_camera
   }
 
   /*
-   * Publish IMU.
-   */
-  void ZR300Nodelet::publishIMU()
-  {
-    prev_imu_ts_device_time_ = -1;
-    while (ros::ok())
-    {
-      if (start_stop_srv_called_ == true)
-      {
-        if (start_camera_ == true)
-        {
-          ROS_INFO_STREAM(nodelet_name_ << " - " << startCamera());
-        }
-        else
-        {
-          ROS_INFO_STREAM(nodelet_name_ << " - " << stopCamera());
-        }
-        start_stop_srv_called_ = false;
-      }
-
-      if (enable_[RS_STREAM_DEPTH] != rs_is_stream_enabled(rs_device_, RS_STREAM_DEPTH, 0))
-      {
-        stopCamera();
-        setStreams();
-        startCamera();
-      }
-
-      if (imu_publisher_.getNumSubscribers() > 0)
-      {
-        std::unique_lock<std::mutex> lock(imu_mutex_);
-
-        // Super sketchy double equals check... Maybe switch to sequence number?
-        if (prev_imu_ts_device_time_ != imu_ts_device_time_)
-        {
-          sensor_msgs::Imu imu_msg = sensor_msgs::Imu();
-          imu_msg.header.stamp = ros::Time(time_sync_.getLocalTimestamp(imu_ts_device_time_));
-          imu_msg.header.frame_id = imu_optical_frame_id_;
-
-          // Setting just the first element to -1.0 because device does not give orientation data
-          imu_msg.orientation_covariance[0] = -1.0;
-
-          imu_msg.angular_velocity = imu_angular_vel_;
-          imu_msg.linear_acceleration = imu_linear_accel_;
-
-          imu_publisher_.publish(imu_msg);
-          prev_imu_ts_device_time_ = imu_ts_device_time_;
-        }
-      }
-    }
-    stopIMU();
-  }
-
-  /*
    * Set up IMU -- overrides base class
    */
   void ZR300Nodelet::setStreams()
@@ -596,24 +535,37 @@ namespace realsense_camera
   {
     motion_handler_ = [&](rs::motion_data entry)  // NOLINT(build/c++11)
     {
-      std::unique_lock<std::mutex> lock(imu_mutex_);
+      static geometry_msgs::Vector3 imu_linear_accel;
       if (entry.timestamp_data.source_id == RS_EVENT_IMU_GYRO)
       {
-        imu_angular_vel_.x = entry.axes[0];
-        imu_angular_vel_.y = entry.axes[1];
-        imu_angular_vel_.z = entry.axes[2];
+        geometry_msgs::Vector3 imu_angular_vel;
+        imu_angular_vel.x = entry.axes[0];
+        imu_angular_vel.y = entry.axes[1];
+        imu_angular_vel.z = entry.axes[2];
         // Only update timestamp on gyro!
-        imu_ts_device_time_ = static_cast<double>(entry.timestamp_data.timestamp) * MILLISECONDS_TO_SECONDS;
+        double imu_ts_device_time = static_cast<double>(entry.timestamp_data.timestamp) * MILLISECONDS_TO_SECONDS;
+
+        //send IMU data
+        sensor_msgs::Imu imu_msg = sensor_msgs::Imu();
+        imu_msg.header.stamp = ros::Time(time_sync_.getLocalTimestamp(imu_ts_device_time));
+        imu_msg.header.frame_id = imu_optical_frame_id_;
+
+        // Setting just the first element to -1.0 because device does not give orientation data
+        imu_msg.orientation_covariance[0] = -1.0;
+
+        imu_msg.angular_velocity = imu_angular_vel;
+        imu_msg.linear_acceleration = imu_linear_accel;
+
+        imu_publisher_.publish(imu_msg);
       }
       else if (entry.timestamp_data.source_id == RS_EVENT_IMU_ACCEL)
       {
-        imu_linear_accel_.x = entry.axes[0];
-        imu_linear_accel_.y = entry.axes[1];
-        imu_linear_accel_.z = entry.axes[2];
+        imu_linear_accel.x = entry.axes[0];
+        imu_linear_accel.y = entry.axes[1];
+        imu_linear_accel.z = entry.axes[2];
       }
 
-      ROS_DEBUG_STREAM(" - Motion,\t host time " << imu_ts_device_time_
-          << "\ttimestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*MILLISECONDS_TO_SECONDS
+      ROS_DEBUG_STREAM(" - Motion,\t timestamp: " << std::setprecision(8) << (double)entry.timestamp_data.timestamp*MILLISECONDS_TO_SECONDS
           << "\tsource: " << (rs::event)entry.timestamp_data.source_id
           << "\tframe_num: " << entry.timestamp_data.frame_number
           << "\tx: " << std::setprecision(5) <<  entry.axes[0]
@@ -904,8 +856,6 @@ namespace realsense_camera
 
   bool ZR300Nodelet::findTimestamp(unsigned short sequence_number, rs_event_source source,
       int* timestamp_imu, ros::Time* timestamp) {
-    std::lock_guard<std::mutex> lock(timestamp_mutex_);
-
     for (auto ts : timestamp_queue_) {
       if (ts.source_id == source && ts.frame_number == sequence_number) {
         if (timestamp_imu) {


### PR DESCRIPTION
Fixes Issue: IMU polling was always using 100% of a core (now uses ~20% of one on my pc)

Is there any reason why the IMU values were saved to variables and then transmitted by a separate polling thread?
In this pull request I change it so the IMU messages are sent whenever the gyro gives a new reading. This removes the need for a lot of class scope variables, the separate IMU thread and its mutex. I feel there has to be some horrible downside I am not seeing here given the complexity of the previous approach compared to this one.