### PR TITLE
Changed all sequence numbers to unsigned ints.

### DIFF
--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -120,7 +120,7 @@ protected:
   double ts_[STREAM_COUNT];
   // Sequence numbers (or frame IDs in the realsense frame, not TF) for images,
   // for timestamp resolution and publishing.
-  unsigned int sequence_ids_[STREAM_COUNT];
+  uint64_t sequence_ids_[STREAM_COUNT];
   // What factor to subsample the FPS by. INTEGER ONLY. Because it's easier.
   int subsample_fps_[STREAM_COUNT] = {1};
   std::string frame_id_[STREAM_COUNT];
@@ -175,7 +175,7 @@ protected:
   virtual std::string startCamera();
   virtual std::string stopCamera();
   virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts,
-                                 unsigned int sequence_number);
+                                 uint64_t sequence_number);
   virtual void publishTopic(rs_stream stream_index, rs::frame &  frame);
   virtual void setImageData(rs_stream stream_index, rs::frame &  frame);
   virtual void publishPCTopic();

--- a/realsense_camera/include/realsense_camera/base_nodelet.h
+++ b/realsense_camera/include/realsense_camera/base_nodelet.h
@@ -120,7 +120,7 @@ protected:
   double ts_[STREAM_COUNT];
   // Sequence numbers (or frame IDs in the realsense frame, not TF) for images,
   // for timestamp resolution and publishing.
-  int sequence_ids_[STREAM_COUNT];
+  unsigned int sequence_ids_[STREAM_COUNT];
   // What factor to subsample the FPS by. INTEGER ONLY. Because it's easier.
   int subsample_fps_[STREAM_COUNT] = {1};
   std::string frame_id_[STREAM_COUNT];
@@ -174,7 +174,8 @@ protected:
   virtual void disableStream(rs_stream stream_index);
   virtual std::string startCamera();
   virtual std::string stopCamera();
-  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number);
+  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts,
+                                 unsigned int sequence_number);
   virtual void publishTopic(rs_stream stream_index, rs::frame &  frame);
   virtual void setImageData(rs_stream stream_index, rs::frame &  frame);
   virtual void publishPCTopic();

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -91,8 +91,8 @@ protected:
   void setFrameCallbacks();
   std::function<void(rs::frame f)> fisheye_frame_handler_, ir2_frame_handler_;
   void stopIMU();
-  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, unsigned int sequence_number);
-  bool findTimestamp(unsigned int sequence_number, rs_event_source source,
+  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, uint64_t sequence_number);
+  bool findTimestamp(uint64_t sequence_number, rs_event_source source,
       int* timestamp_imu, ros::Time* timestamp);
 
 };

--- a/realsense_camera/include/realsense_camera/zr300_nodelet.h
+++ b/realsense_camera/include/realsense_camera/zr300_nodelet.h
@@ -91,8 +91,8 @@ protected:
   void setFrameCallbacks();
   std::function<void(rs::frame f)> fisheye_frame_handler_, ir2_frame_handler_;
   void stopIMU();
-  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number);
-  bool findTimestamp(unsigned short sequence_number, rs_event_source source,
+  virtual ros::Time getTimestamp(rs_stream stream_index, double frame_ts, unsigned int sequence_number);
+  bool findTimestamp(unsigned int sequence_number, rs_event_source source,
       int* timestamp_imu, ros::Time* timestamp);
 
 };

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -853,7 +853,8 @@ namespace realsense_camera
   /*
    * Determine the timestamp for the publish topic.
    */
-  ros::Time BaseNodelet::getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number)
+  ros::Time BaseNodelet::getTimestamp(rs_stream stream_index, double frame_ts,
+                                      unsigned int sequence_number)
   {
     return ros::Time(camera_start_ts_) + ros::Duration(frame_ts * 0.001);
   }

--- a/realsense_camera/src/base_nodelet.cpp
+++ b/realsense_camera/src/base_nodelet.cpp
@@ -854,7 +854,7 @@ namespace realsense_camera
    * Determine the timestamp for the publish topic.
    */
   ros::Time BaseNodelet::getTimestamp(rs_stream stream_index, double frame_ts,
-                                      unsigned int sequence_number)
+                                      uint64_t sequence_number)
   {
     return ros::Time(camera_start_ts_) + ros::Duration(frame_ts * 0.001);
   }

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -842,7 +842,7 @@ namespace realsense_camera
   }
 
   ros::Time ZR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts,
-                                       unsigned int sequence_number) {
+                                       uint64_t sequence_number) {
     ros::Time local_timestamp;
 
     if (stream_index == RS_STREAM_FISHEYE) {
@@ -855,9 +855,8 @@ namespace realsense_camera
     return local_timestamp;
   }
 
-  bool ZR300Nodelet::findTimestamp(unsigned int sequence_number, rs_event_source source,
+  bool ZR300Nodelet::findTimestamp(uint64_t sequence_number, rs_event_source source,
       int* timestamp_imu, ros::Time* timestamp) {
-    ROS_ERROR_STREAM(sequence_number);
     for (auto ts : timestamp_queue_) {
       if (ts.source_id == source && ts.frame_number == sequence_number) {
         if (timestamp_imu) {

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -841,7 +841,8 @@ namespace realsense_camera
     checkError();
   }
 
-  ros::Time ZR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts, int sequence_number) {
+  ros::Time ZR300Nodelet::getTimestamp(rs_stream stream_index, double frame_ts,
+                                       unsigned int sequence_number) {
     ros::Time local_timestamp;
 
     if (stream_index == RS_STREAM_FISHEYE) {
@@ -854,8 +855,9 @@ namespace realsense_camera
     return local_timestamp;
   }
 
-  bool ZR300Nodelet::findTimestamp(unsigned short sequence_number, rs_event_source source,
+  bool ZR300Nodelet::findTimestamp(unsigned int sequence_number, rs_event_source source,
       int* timestamp_imu, ros::Time* timestamp) {
+    ROS_ERROR_STREAM(sequence_number);
     for (auto ts : timestamp_queue_) {
       if (ts.source_id == source && ts.frame_number == sequence_number) {
         if (timestamp_imu) {


### PR DESCRIPTION
With unsigned int (max value 4294967294) it should be possible to run the sensor at 60 Hz for 829 days without experiencing an overflow. That should be fine.
@helenol ptal