### PR TITLE
Change depth encoding to be ROS standards compliant

### DIFF
--- a/realsense_camera/src/f200_nodelet.cpp
+++ b/realsense_camera/src/f200_nodelet.cpp
@@ -48,7 +48,7 @@ namespace realsense_camera
     unit_step_size_[RS_STREAM_COLOR] = sizeof(unsigned char) * 3;
 
     format_[RS_STREAM_DEPTH] = RS_FORMAT_Z16;
-    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::MONO16;
+    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::TYPE_16UC1;
     cv_type_[RS_STREAM_DEPTH] = CV_16UC1;
     unit_step_size_[RS_STREAM_DEPTH] = sizeof(uint16_t);
 

--- a/realsense_camera/src/r200_nodelet.cpp
+++ b/realsense_camera/src/r200_nodelet.cpp
@@ -50,7 +50,7 @@ namespace realsense_camera
     unit_step_size_[RS_STREAM_COLOR] = sizeof(unsigned char) * 3;
 
     format_[RS_STREAM_DEPTH] = RS_FORMAT_Z16;
-    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::MONO16;
+    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::TYPE_16UC1;
     cv_type_[RS_STREAM_DEPTH] = CV_16UC1;
     unit_step_size_[RS_STREAM_DEPTH] = sizeof(uint16_t);
 

--- a/realsense_camera/src/sr300_nodelet.cpp
+++ b/realsense_camera/src/sr300_nodelet.cpp
@@ -47,7 +47,7 @@ namespace realsense_camera
     unit_step_size_[RS_STREAM_COLOR] = sizeof(unsigned char) * 3;
 
     format_[RS_STREAM_DEPTH] = RS_FORMAT_Z16;
-    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::MONO16;
+    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::TYPE_16UC1;
     cv_type_[RS_STREAM_DEPTH] = CV_16UC1;
     unit_step_size_[RS_STREAM_DEPTH] = sizeof(uint16_t);
 

--- a/realsense_camera/src/zr300_nodelet.cpp
+++ b/realsense_camera/src/zr300_nodelet.cpp
@@ -59,7 +59,7 @@ namespace realsense_camera
     unit_step_size_[RS_STREAM_COLOR] = sizeof(unsigned char) * 3;
 
     format_[RS_STREAM_DEPTH] = RS_FORMAT_Z16;
-    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::MONO16;
+    encoding_[RS_STREAM_DEPTH] = sensor_msgs::image_encodings::TYPE_16UC1;
     cv_type_[RS_STREAM_DEPTH] = CV_16UC1;
     unit_step_size_[RS_STREAM_DEPTH] = sizeof(uint16_t);
 


### PR DESCRIPTION
mono16 is not an appropriate depth encoding since the image data values do not represent a "color".
Hence its not supported by depth_image_proc . See discussion [here](https://github.com/ros-perception/vision_opencv/issues/175#issuecomment-314099859) for more info.

This PR changes this encoding for all corresponding nodelets.
@ZacharyTaylor @helenol 