### PR TITLE
Fix/sequence reset

### DIFF
--- a/realsense2_camera/include/mavros_timestamp.h
+++ b/realsense2_camera/include/mavros_timestamp.h
@@ -129,7 +129,8 @@ class MavrosTrigger {
     if (ros::service::exists(kTriggerService, false)) {
       mavros_msgs::CommandTriggerControl req;
       req.request.trigger_enable = true;
-      req.request.sequence_reset = 1.0;
+      // This is NOT integration time, this is actually the sequence reset.
+      req.request.cycle_time = 1.0;
 
       ros::service::call(kTriggerService, req);
 

--- a/realsense2_camera/include/mavros_timestamp.h
+++ b/realsense2_camera/include/mavros_timestamp.h
@@ -130,7 +130,7 @@ class MavrosTrigger {
       mavros_msgs::CommandTriggerControl req;
       req.request.trigger_enable = true;
       // This is NOT integration time, this is actually the sequence reset.
-      req.request.integration_time = 1.0;
+      req.request.sequence_reset = 1.0;
 
       ros::service::call(kTriggerService, req);
 

--- a/realsense2_camera/include/mavros_timestamp.h
+++ b/realsense2_camera/include/mavros_timestamp.h
@@ -129,7 +129,6 @@ class MavrosTrigger {
     if (ros::service::exists(kTriggerService, false)) {
       mavros_msgs::CommandTriggerControl req;
       req.request.trigger_enable = true;
-      // This is NOT integration time, this is actually the sequence reset.
       req.request.sequence_reset = 1.0;
 
       ros::service::call(kTriggerService, req);

--- a/realsense2_camera/include/mavros_timestamp.h
+++ b/realsense2_camera/include/mavros_timestamp.h
@@ -129,7 +129,7 @@ class MavrosTrigger {
     if (ros::service::exists(kTriggerService, false)) {
       mavros_msgs::CommandTriggerControl req;
       req.request.trigger_enable = true;
-      // This is NOT integration time, this is actually the sequence reset.
+      // This is NOT cycle time, this is actually the sequence reset.
       req.request.cycle_time = 1.0;
 
       ros::service::call(kTriggerService, req);


### PR DESCRIPTION
Time sync using the px4 works again. Several updates to the field name in this mavros message had broken things. 